### PR TITLE
Fix equipment initialization when table missing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -79,27 +79,30 @@ def create_app(config=None):
     # --- Populate Equipment Table from Hardcoded Data (if empty) ---
     from app.models.equipment_data import EQUIPMENT_DATA
     from app.models.equipment import Equipment
+    from sqlalchemy import inspect
     with app.app_context():
-        if Equipment.query.count() == 0:
-            for item in EQUIPMENT_DATA:
-                type_value = item['type'].value if hasattr(item['type'], 'value') else item['type']
-                slot_value = item['slot'].value if hasattr(item['slot'], 'value') else item['slot']
-                eq = Equipment(
-                    name=item['name'],
-                    description=item['description'],
-                    type=type_value,
-                    slot=slot_value,
-                    cost=item['cost'],
-                    level_requirement=item['level_requirement'],
-                    health_bonus=item['health_bonus'],
-                    strength_bonus=item['strength_bonus'],
-                    defense_bonus=item['defense_bonus'],
-                    rarity=item['rarity'],
-                    image_url=item['image_url'],
-                    class_restriction=item.get('class_restriction'),
-                )
-                db.session.add(eq)
-            db.session.commit()
+        inspector = inspect(db.engine)
+        if inspector.has_table(Equipment.__tablename__):
+            if Equipment.query.count() == 0:
+                for item in EQUIPMENT_DATA:
+                    type_value = item['type'].value if hasattr(item['type'], 'value') else item['type']
+                    slot_value = item['slot'].value if hasattr(item['slot'], 'value') else item['slot']
+                    eq = Equipment(
+                        name=item['name'],
+                        description=item['description'],
+                        type=type_value,
+                        slot=slot_value,
+                        cost=item['cost'],
+                        level_requirement=item['level_requirement'],
+                        health_bonus=item['health_bonus'],
+                        strength_bonus=item['strength_bonus'],
+                        defense_bonus=item['defense_bonus'],
+                        rarity=item['rarity'],
+                        image_url=item['image_url'],
+                        class_restriction=item.get('class_restriction'),
+                    )
+                    db.session.add(eq)
+                db.session.commit()
     # --------------------------------------------------------------
 
     return app


### PR DESCRIPTION
## Summary
- avoid querying Equipment table before it's created

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878d5f9d67c832b86bac3c3829f604a